### PR TITLE
Add creature builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,17 @@ A very basic quick roller. Has all the NPC data available in tables with clickab
 
 Right clicking will roll 2x the value, even for the d20 rolls. If you have a token selected the chat card will display its name.
 
-Found in the journals tab. 
+Found in the journals tab.
+
+### Creature Builder
+A tool to create creatures from scratch, using the recommended values from the Game Mastery Guide.
+
+To use the Creature Builder you have to create a blank NPC. When you open its Character Sheet, you can find a button at the top. Clicking this button will open the creature builder.
+
+You will find various values you can choose from. per default, all values are at moderate. 
+Please take a look at the GMG to find out how to balance your creature.
+When you are happy with your values for a creature click the save button.
+This will override the current values of the npc.
 
 ### Token Setup
 If you name all your token images in the below manner, it can smartly map token names for a specified folder automatically. Supported file formats are jpg, jpeg, png, gif, webp and svg - the token setup tool will detect any of these formats, but you must use the same format for all your tokens of a specific creature because of limitations with Foundry.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Please take a look at the GMG to find out how to balance your creature.
 When you are happy with your values for a creature click the save button.
 This will override the current values of the npc.
 
+The GMG suggest various Road Maps.
+Those can be selected in the road map section.
+Select the desired road map from the options and click the Apply road map button.
+
 ### Token Setup
 If you name all your token images in the below manner, it can smartly map token names for a specified folder automatically. Supported file formats are jpg, jpeg, png, gif, webp and svg - the token setup tool will detect any of these formats, but you must use the same format for all your tokens of a specific creature because of limitations with Foundry.
 

--- a/src/css/bundle.scss
+++ b/src/css/bundle.scss
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+@import './creature-builder/main';
 @import './roll-app/main';
 @import './loot-app/main';
 @import './settings-app/main';

--- a/src/css/creature-builder/main.scss
+++ b/src/css/creature-builder/main.scss
@@ -1,0 +1,10 @@
+.creature-builder {
+  .sheet-body {
+    h2, h3 {
+      margin-bottom: 0.1em;
+    }
+    .value {
+      margin-left: 1em;
+    }
+  }
+}

--- a/src/css/creature-builder/main.scss
+++ b/src/css/creature-builder/main.scss
@@ -3,7 +3,7 @@
     h2, h3 {
       margin-bottom: 0.1em;
     }
-    .value {
+    .entry {
       margin-left: 1em;
     }
   }

--- a/src/module/Main.ts
+++ b/src/module/Main.ts
@@ -204,7 +204,7 @@ function enableNpcBuilderButton(sheet: ActorSheet, html: JQuery) {
 
     let button = $(`<a class="popout" style><i class="fas fa-book"></i>Creature Builder</a>`);
     button.on('click', () => {
-        new CreatureBuilder(actor).render(true);
+        new CreatureBuilder(actor, {}).render(true);
     });
 
     element.after(button);

--- a/src/module/Main.ts
+++ b/src/module/Main.ts
@@ -45,8 +45,8 @@ Hooks.on('setup', () => {
     if (Settings.get(Settings.FEATURES.QUANTITIES)) {
         Hooks.on('renderActorSheet', onQuantitiesHook);
     }
-    if (Settings.get(Settings.FEATURES.ROLL_APP)) {
-        Hooks.on('renderActorSheet', enableNpcBuilderButton);
+    if (Settings.get(Settings.FEATURES.CREATURE_BUILDER)) {
+        Hooks.on('renderActorSheet', enableCreatureBuilderButton);
     }
     if (Settings.get(Settings.FEATURES.ROLL_APP)) {
         Hooks.on('renderJournalDirectory', enableRollAppButton);
@@ -190,7 +190,7 @@ function enableRollAppButton(app: Application, html: JQuery) {
     footer.append(button);
 }
 
-function enableNpcBuilderButton(sheet: ActorSheet, html: JQuery) {
+function enableCreatureBuilderButton(sheet: ActorSheet, html: JQuery) {
     // Only inject the link if the actor is of type "character" and the user has permission to update it
     const actor = sheet.actor;
     if (!(actor.data.type === "npc" && actor.can(game.user, "update"))) {

--- a/src/module/Main.ts
+++ b/src/module/Main.ts
@@ -25,6 +25,7 @@ import secretSkillRoll from './macros/secret-skill-roll';
 import distributeXp from './macros/distribute-xp';
 import { distributeHeroPoints } from './macros/distribute-hero-points';
 import { groupSave, registerGroupSaveHooks } from './macros/group-saves';
+import CreatureBuilder from './creature-builder/CreatureBuilder';
 
 Hooks.on('init', Settings.registerAllSettings);
 
@@ -43,6 +44,9 @@ Hooks.on('setup', () => {
     }
     if (Settings.get(Settings.FEATURES.QUANTITIES)) {
         Hooks.on('renderActorSheet', onQuantitiesHook);
+    }
+    if (Settings.get(Settings.FEATURES.ROLL_APP)) {
+        Hooks.on('renderActorSheet', enableNpcBuilderButton);
     }
     if (Settings.get(Settings.FEATURES.ROLL_APP)) {
         Hooks.on('renderJournalDirectory', enableRollAppButton);
@@ -184,6 +188,26 @@ function enableRollAppButton(app: Application, html: JQuery) {
         html.append(footer);
     }
     footer.append(button);
+}
+
+function enableNpcBuilderButton(sheet: ActorSheet, html: JQuery) {
+    // Only inject the link if the actor is of type "character" and the user has permission to update it
+    const actor = sheet.actor;
+    if (!(actor.data.type === "npc" && actor.can(game.user, "update"))) {
+        return;
+    }
+
+    let element = html.find(".window-header .window-title");
+    if (element.length != 1) {
+        return;
+    }
+
+    let button = $(`<a class="popout" style><i class="fas fa-book"></i>Creature Builder</a>`);
+    button.on('click', () => {
+        new CreatureBuilder(actor).render(true);
+    });
+
+    element.after(button);
 }
 
 function enableHeroPoints(app: Application, html: JQuery, renderData: any) {

--- a/src/module/creature-builder/CreatureBuilder.ts
+++ b/src/module/creature-builder/CreatureBuilder.ts
@@ -61,18 +61,23 @@ export default class CreatureBuilder extends FormApplication {
 
     private async updateSkill(formData: any, buttonFieldName: string, valueToBeInsertedIntoNpc) {
         if (formData[buttonFieldName] !== ValueCategory.none) {
-            const data: any = {
-                name: buttonFieldName,
-                type: 'lore',
-                data: {
-                    mod: {
-                        value: valueToBeInsertedIntoNpc,
-                    },
-                },
-            };
+            const data = this.createNewSkillData(buttonFieldName, valueToBeInsertedIntoNpc);
 
             await this.object.createOwnedItem(data);
         }
+    }
+
+    private createNewSkillData(buttonFieldName: string, valueToBeInsertedIntoNpc) {
+        const data: any = {
+            name: buttonFieldName,
+            type: 'lore',
+            data: {
+                mod: {
+                    value: valueToBeInsertedIntoNpc,
+                },
+            },
+        };
+        return data;
     }
 
     private async updateAttack(formData: any, strikeInfo: CreatureValueCategory, level: number) {
@@ -91,6 +96,12 @@ export default class CreatureBuilder extends FormApplication {
             }
         }
 
+        const data = this.createNewStrikeData(strikeDamage, strikeBonus);
+
+        await this.object.createOwnedItem(data);
+    }
+
+    private createNewStrikeData(strikeDamage: string, strikeBonus: number) {
         const data: any = {
             name: 'New Melee',
             type: 'melee',
@@ -98,14 +109,13 @@ export default class CreatureBuilder extends FormApplication {
                 damageRolls: [
                     {
                         damage: strikeDamage,
-                    }
+                    },
                 ],
                 bonus: {
                     value: strikeBonus,
-                }
-            }
-        }
-
-        await this.object.createOwnedItem(data);
+                },
+            },
+        };
+        return data;
     }
 }

--- a/src/module/creature-builder/CreatureBuilder.ts
+++ b/src/module/creature-builder/CreatureBuilder.ts
@@ -1,0 +1,24 @@
+import { MODULE_NAME } from '../Constants';
+import { ROLL_APP_DATA } from '../roll-app/RollAppData';
+
+export default class CreatureBuilder extends FormApplication {
+    static get defaultOptions() {
+        const options = super.defaultOptions;
+        options.title = 'Creature Builder';
+        options.template = `modules/${MODULE_NAME}/templates/creature-builder/index.html`;
+        options.classes = options.classes ?? [];
+        options.classes = [...options.classes, 'creature-builder'];
+        options.width = 800;
+        options.height = 'auto';
+        options.resizable = true;
+        return options;
+    }
+
+    protected _updateObject(event: Event | JQuery.Event, formData: any): Promise<any> {
+        const level = formData['data.details.level.value'];
+
+        formData['data.attributes.perception.value'] = ROLL_APP_DATA.perception[level + 1][formData.perception];
+
+        return this.object.update(formData);
+    }
+}

--- a/src/module/creature-builder/CreatureBuilder.ts
+++ b/src/module/creature-builder/CreatureBuilder.ts
@@ -3,13 +3,15 @@ import { ROLL_APP_DATA } from '../roll-app/RollAppData';
 import {
     CreatureValueCategory,
     CreatureValueEntry,
-    DefaultCreatureValues, Roadmap,
+    DefaultCreatureValues,
+    Roadmap,
     ROADMAPS,
     StatisticScale,
 } from './CreatureBuilderData';
 
 export default class CreatureBuilder extends FormApplication {
-    valueCategories: CreatureValueCategory[] = DefaultCreatureValues;
+    // Create copy of the default values
+    valueCategories: CreatureValueCategory[] = JSON.parse(JSON.stringify(DefaultCreatureValues));
     selectedRoadmap: Roadmap = {
         name: 'Default',
         defaultValues: new Map(),
@@ -41,6 +43,8 @@ export default class CreatureBuilder extends FormApplication {
 
                 if (this.selectedRoadmap.defaultValues.has(name)) {
                     valueCategories[i].associatedValues[j].defaultValue = this.selectedRoadmap.defaultValues.get(name) ?? StatisticScale.moderate;
+                } else {
+                    valueCategories[i].associatedValues[j].defaultValue = DefaultCreatureValues[i].associatedValues[j].defaultValue;
                 }
             }
         }

--- a/src/module/creature-builder/CreatureBuilder.ts
+++ b/src/module/creature-builder/CreatureBuilder.ts
@@ -14,6 +14,7 @@ export default class CreatureBuilder extends FormApplication {
     valueCategories: CreatureValueCategory[] = JSON.parse(JSON.stringify(DefaultCreatureValues));
     selectedRoadmap: Roadmap = {
         name: 'Default',
+        tooltip: 'None',
         defaultValues: new Map(),
     };
 

--- a/src/module/creature-builder/CreatureBuilder.ts
+++ b/src/module/creature-builder/CreatureBuilder.ts
@@ -1,41 +1,9 @@
 import { MODULE_NAME } from '../Constants';
 import { ROLL_APP_DATA } from '../roll-app/RollAppData';
-
-enum ValueCategory {
-    extreme = 'extreme',
-    high = 'high',
-    moderate = 'moderate',
-    low = 'low',
-    terrible = 'terrible',
-    abysmal = 'abysmal',
-}
-
-class CreatureValueEntry {
-    descriptor: string;
-    actorField: string;
-    availableValues: ValueCategory[];
-    defaultValue: ValueCategory;
-
-    constructor(descriptor: string, actorField: string, availableValues: ValueCategory[], defaultValue: ValueCategory) {
-        this.descriptor = descriptor;
-        this.actorField = actorField;
-        this.availableValues = availableValues;
-        this.defaultValue = defaultValue;
-    }
-}
+import { CreatureValueEntry, DefaultCreatureValues } from './CreatureBuilderData';
 
 export default class CreatureBuilder extends FormApplication {
-    valueEntries: CreatureValueEntry[];
-
-    constructor(object: any, options: FormApplicationOptions) {
-        super(object, options);
-
-        this.valueEntries = [
-            new CreatureValueEntry('perception', 'data.attributes.perception.value',
-                [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible],
-                ValueCategory.extreme),
-        ];
-    }
+    valueEntries: CreatureValueEntry[] = DefaultCreatureValues;
 
     static get defaultOptions() {
         const options = super.defaultOptions;
@@ -60,10 +28,13 @@ export default class CreatureBuilder extends FormApplication {
     protected _updateObject(event: Event | JQuery.Event, formData: any): Promise<any> {
         const level = formData['data.details.level.value'];
 
+        const newFormData = {};
+        newFormData['data.details.level.value'] = level;
+
         for (const valueEntry of this.valueEntries) {
-            formData[valueEntry.actorField] = ROLL_APP_DATA[valueEntry.descriptor][level + 1][formData[valueEntry.descriptor]];
+            newFormData[valueEntry.actorField] = ROLL_APP_DATA[valueEntry.descriptor][level + 1][formData[valueEntry.name]];
         }
 
-        return this.object.update(formData);
+        return this.object.update(newFormData);
     }
 }

--- a/src/module/creature-builder/CreatureBuilder.ts
+++ b/src/module/creature-builder/CreatureBuilder.ts
@@ -41,6 +41,8 @@ export default class CreatureBuilder extends FormApplication {
 
                     if (category.descriptor === 'skill') {
                         await this.updateSkill(formData, buttonFieldName, valueToBeInsertedIntoNpc);
+                    } else if (category.descriptor === 'hitPoints') {
+                        this.updateHitPoints(valueToBeInsertedIntoNpc, value, newFormData);
                     } else {
                         newFormData[value.actorField] = valueToBeInsertedIntoNpc;
                     }
@@ -51,11 +53,19 @@ export default class CreatureBuilder extends FormApplication {
         return this.object.update(newFormData);
     }
 
+    private updateHitPoints(valueToBeInsertedIntoNpc, value: CreatureValueEntry, newFormData: {}) {
+        const hitPointsValue = valueToBeInsertedIntoNpc.maximum;
+        const hitPointFieldsToUpdate = value.actorField.split(',');
+        for (const field of hitPointFieldsToUpdate) {
+            newFormData[field] = hitPointsValue;
+        }
+    }
+
     private static getButtonFieldName(value: CreatureValueEntry, category: CreatureValueCategory) : string {
         return value.name === undefined ? category.name : value.name;
     }
 
-    private static getValueToBeInsertedIntoNpc(descriptor: string, level, formData: any, buttonFieldName: string) : number | string {
+    private static getValueToBeInsertedIntoNpc(descriptor: string, level, formData: any, buttonFieldName: string) : number | string | any {
         return ROLL_APP_DATA[descriptor][level + 1][formData[buttonFieldName]];
     }
 

--- a/src/module/creature-builder/CreatureBuilder.ts
+++ b/src/module/creature-builder/CreatureBuilder.ts
@@ -1,7 +1,42 @@
 import { MODULE_NAME } from '../Constants';
 import { ROLL_APP_DATA } from '../roll-app/RollAppData';
 
+enum ValueCategory {
+    extreme = 'extreme',
+    high = 'high',
+    moderate = 'moderate',
+    low = 'low',
+    terrible = 'terrible',
+    abysmal = 'abysmal',
+}
+
+class CreatureValueEntry {
+    descriptor: string;
+    actorField: string;
+    availableValues: ValueCategory[];
+    defaultValue: ValueCategory;
+
+    constructor(descriptor: string, actorField: string, availableValues: ValueCategory[], defaultValue: ValueCategory) {
+        this.descriptor = descriptor;
+        this.actorField = actorField;
+        this.availableValues = availableValues;
+        this.defaultValue = defaultValue;
+    }
+}
+
 export default class CreatureBuilder extends FormApplication {
+    valueEntries: CreatureValueEntry[];
+
+    constructor(object: any, options: FormApplicationOptions) {
+        super(object, options);
+
+        this.valueEntries = [
+            new CreatureValueEntry('perception', 'data.attributes.perception.value',
+                [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible],
+                ValueCategory.extreme),
+        ];
+    }
+
     static get defaultOptions() {
         const options = super.defaultOptions;
         options.title = 'Creature Builder';
@@ -14,10 +49,20 @@ export default class CreatureBuilder extends FormApplication {
         return options;
     }
 
+    getData(options?: any): any {
+        const renderData = super.getData(options);
+
+        renderData['valueEntries'] = this.valueEntries;
+
+        return renderData;
+    }
+
     protected _updateObject(event: Event | JQuery.Event, formData: any): Promise<any> {
         const level = formData['data.details.level.value'];
 
-        formData['data.attributes.perception.value'] = ROLL_APP_DATA.perception[level + 1][formData.perception];
+        for (const valueEntry of this.valueEntries) {
+            formData[valueEntry.actorField] = ROLL_APP_DATA[valueEntry.descriptor][level + 1][formData[valueEntry.descriptor]];
+        }
 
         return this.object.update(formData);
     }

--- a/src/module/creature-builder/CreatureBuilder.ts
+++ b/src/module/creature-builder/CreatureBuilder.ts
@@ -1,9 +1,9 @@
 import { MODULE_NAME } from '../Constants';
 import { ROLL_APP_DATA } from '../roll-app/RollAppData';
-import { CreatureValueEntry, DefaultCreatureValues } from './CreatureBuilderData';
+import { CreatureValueCategory, CreatureValueEntry, DefaultCreatureValues } from './CreatureBuilderData';
 
 export default class CreatureBuilder extends FormApplication {
-    valueEntries: CreatureValueEntry[] = DefaultCreatureValues;
+    valueCategories: CreatureValueCategory[] = DefaultCreatureValues;
 
     static get defaultOptions() {
         const options = super.defaultOptions;
@@ -20,7 +20,7 @@ export default class CreatureBuilder extends FormApplication {
     getData(options?: any): any {
         const renderData = super.getData(options);
 
-        renderData['valueEntries'] = this.valueEntries;
+        renderData['valueCategories'] = this.valueCategories;
 
         return renderData;
     }
@@ -31,8 +31,12 @@ export default class CreatureBuilder extends FormApplication {
         const newFormData = {};
         newFormData['data.details.level.value'] = level;
 
-        for (const valueEntry of this.valueEntries) {
-            newFormData[valueEntry.actorField] = ROLL_APP_DATA[valueEntry.descriptor][level + 1][formData[valueEntry.name]];
+        for (const category of this.valueCategories) {
+            for (const value of category.associatedValues) {
+                const buttonFieldName = value.name === undefined ? category.name : value.name;
+
+                newFormData[value.actorField] = ROLL_APP_DATA[category.descriptor][level + 1][formData[buttonFieldName]];
+            }
         }
 
         return this.object.update(newFormData);

--- a/src/module/creature-builder/CreatureBuilderData.ts
+++ b/src/module/creature-builder/CreatureBuilderData.ts
@@ -1,13 +1,3 @@
-export enum StatisticScale {
-    extreme = 'extreme',
-    high = 'high',
-    moderate = 'moderate',
-    low = 'low',
-    terrible = 'terrible',
-    abysmal = 'abysmal',
-    none = 'none', // Required for values that would allow for a null option
-}
-
 export enum AdjustableStatistics {
     str = 'Strength',
     dex = 'Dexterity',
@@ -39,223 +29,245 @@ export enum AdjustableStatistics {
     thievery = 'Thievery',
     strikeBonus = 'Strike Attack Bonus',
     strikeDamage = 'Strike Damage',
+    spellcasting = 'Spellcasting',
+}
+
+export enum StatisticOptions {
+    extreme = 'extreme',
+    high = 'high',
+    moderate = 'moderate',
+    low = 'low',
+    terrible = 'terrible',
+    abysmal = 'abysmal',
+    none = 'none', // Required for values that would allow for a null option
 }
 
 export class CreatureValueEntry {
     name?: string; // Overrides values from the parent category
     descriptor?: string; // Overrides values from the parent category
     actorField: string;
-    defaultValue: StatisticScale;
+    defaultValue: StatisticOptions;
 }
 
 export class CreatureValueCategory {
     name: string;
     descriptor: string;
-    availableValues: StatisticScale[];
+    availableValues: StatisticOptions[];
     associatedValues: CreatureValueEntry[];
 }
 
 export class Roadmap {
     name: string;
     tooltip: string;
-    defaultValues: Map<string, StatisticScale>;
+    defaultValues: Map<string, StatisticOptions>;
 }
 
 export const DefaultCreatureValues: CreatureValueCategory[] = [
     {
         name: 'Abilities',
         descriptor: 'abilityScore',
-        availableValues: [StatisticScale.extreme, StatisticScale.high, StatisticScale.moderate, StatisticScale.low, StatisticScale.terrible, StatisticScale.abysmal],
+        availableValues: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low, StatisticOptions.terrible, StatisticOptions.abysmal],
         associatedValues: [
             {
                 name: AdjustableStatistics.str,
                 actorField: 'data.abilities.str.mod',
-                defaultValue: StatisticScale.moderate
+                defaultValue: StatisticOptions.moderate
             },
             {
                 name: AdjustableStatistics.dex,
                 actorField: 'data.abilities.dex.mod',
-                defaultValue: StatisticScale.moderate
+                defaultValue: StatisticOptions.moderate
             },
             {
                 name: AdjustableStatistics.con,
                 actorField: 'data.abilities.con.mod',
-                defaultValue: StatisticScale.moderate
+                defaultValue: StatisticOptions.moderate
             },
             {
                 name: AdjustableStatistics.int,
                 actorField: 'data.abilities.int.mod',
-                defaultValue: StatisticScale.moderate
+                defaultValue: StatisticOptions.moderate
             },
             {
                 name: AdjustableStatistics.wis,
                 actorField: 'data.abilities.wis.mod',
-                defaultValue: StatisticScale.moderate
+                defaultValue: StatisticOptions.moderate
             },
             {
                 name: AdjustableStatistics.cha,
                 actorField: 'data.abilities.cha.mod',
-                defaultValue: StatisticScale.moderate
+                defaultValue: StatisticOptions.moderate
             }
         ]
     },
     {
         name: AdjustableStatistics.per,
         descriptor: 'perception',
-        availableValues: [StatisticScale.extreme, StatisticScale.high, StatisticScale.moderate, StatisticScale.low, StatisticScale.terrible],
+        availableValues: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low, StatisticOptions.terrible],
         associatedValues: [
             {
                 actorField: 'data.attributes.perception.value',
-                defaultValue: StatisticScale.moderate
+                defaultValue: StatisticOptions.moderate
             }
         ]
     },
     {
         name: AdjustableStatistics.ac,
         descriptor: 'armorClass',
-        availableValues: [StatisticScale.extreme, StatisticScale.high, StatisticScale.moderate, StatisticScale.low],
+        availableValues: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low],
         associatedValues: [
             {
                 actorField: 'data.attributes.ac.value',
-                defaultValue: StatisticScale.moderate
+                defaultValue: StatisticOptions.moderate
             }
         ]
     },
     {
         name: AdjustableStatistics.hp,
         descriptor: 'hitPoints',
-        availableValues: [StatisticScale.high, StatisticScale.moderate, StatisticScale.low],
+        availableValues: [StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low],
         associatedValues: [
             {
                 actorField: 'data.attributes.hp.value,data.attributes.hp.max',
-                defaultValue: StatisticScale.moderate
+                defaultValue: StatisticOptions.moderate
             }
         ]
     },
     {
         name: 'Saving Throws',
         descriptor: 'savingThrow',
-        availableValues: [StatisticScale.extreme, StatisticScale.high, StatisticScale.moderate, StatisticScale.low, StatisticScale.terrible],
+        availableValues: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low, StatisticOptions.terrible],
         associatedValues: [
             {
                 name: AdjustableStatistics.fort,
                 actorField: 'data.saves.fortitude.value',
-                defaultValue: StatisticScale.moderate
+                defaultValue: StatisticOptions.moderate
             },
             {
                 name: AdjustableStatistics.ref,
                 actorField: 'data.saves.reflex.value',
-                defaultValue: StatisticScale.moderate
+                defaultValue: StatisticOptions.moderate
             },
             {
                 name: AdjustableStatistics.wil,
                 actorField: 'data.saves.will.value',
-                defaultValue: StatisticScale.moderate
+                defaultValue: StatisticOptions.moderate
             }]
     },
     {
         name: 'Skills',
         descriptor: 'skill',
-        availableValues: [StatisticScale.extreme, StatisticScale.high, StatisticScale.moderate, StatisticScale.low, StatisticScale.none],
+        availableValues: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low, StatisticOptions.none],
         associatedValues: [
             {
                 name: AdjustableStatistics.acrobatics,
                 actorField: 'none',
-                defaultValue: StatisticScale.none
+                defaultValue: StatisticOptions.none
             },
             {
                 name: AdjustableStatistics.arcana,
                 actorField: 'none',
-                defaultValue: StatisticScale.none
+                defaultValue: StatisticOptions.none
             },
             {
                 name: AdjustableStatistics.athletics,
                 actorField: 'none',
-                defaultValue: StatisticScale.none
+                defaultValue: StatisticOptions.none
             },
             {
                 name: AdjustableStatistics.crafting,
                 actorField: 'none',
-                defaultValue: StatisticScale.none
+                defaultValue: StatisticOptions.none
             },
             {
                 name: AdjustableStatistics.deception,
                 actorField: 'none',
-                defaultValue: StatisticScale.none
+                defaultValue: StatisticOptions.none
             },
             {
                 name: AdjustableStatistics.diplomacy,
                 actorField: 'none',
-                defaultValue: StatisticScale.none
+                defaultValue: StatisticOptions.none
             },
             {
                 name: AdjustableStatistics.intimidation,
                 actorField: 'none',
-                defaultValue: StatisticScale.none
+                defaultValue: StatisticOptions.none
             },
             {
                 name: AdjustableStatistics.medicine,
                 actorField: 'none',
-                defaultValue: StatisticScale.none
+                defaultValue: StatisticOptions.none
             },
             {
                 name: AdjustableStatistics.nature,
                 actorField: 'none',
-                defaultValue: StatisticScale.none
+                defaultValue: StatisticOptions.none
             },
             {
                 name: AdjustableStatistics.occultism,
                 actorField: 'none',
-                defaultValue: StatisticScale.none
+                defaultValue: StatisticOptions.none
             },
             {
                 name: AdjustableStatistics.performance,
                 actorField: 'none',
-                defaultValue: StatisticScale.none
+                defaultValue: StatisticOptions.none
             },
             {
                 name: AdjustableStatistics.religion,
                 actorField: 'none',
-                defaultValue: StatisticScale.none
+                defaultValue: StatisticOptions.none
             },
             {
                 name: AdjustableStatistics.society,
                 actorField: 'none',
-                defaultValue: StatisticScale.none
+                defaultValue: StatisticOptions.none
             },
             {
                 name: AdjustableStatistics.stealth,
                 actorField: 'none',
-                defaultValue: StatisticScale.none
+                defaultValue: StatisticOptions.none
             },
             {
                 name: AdjustableStatistics.survival,
                 actorField: 'none',
-                defaultValue: StatisticScale.none
+                defaultValue: StatisticOptions.none
             },
             {
                 name: AdjustableStatistics.thievery,
                 actorField: 'none',
-                defaultValue: StatisticScale.none
+                defaultValue: StatisticOptions.none
             }]
     },
     {
         name: 'Strike',
         descriptor: 'strike',
-        availableValues: [StatisticScale.extreme, StatisticScale.high, StatisticScale.moderate, StatisticScale.low],
+        availableValues: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low],
         associatedValues: [
             {
                 name: AdjustableStatistics.strikeBonus,
                 actorField: 'none',
                 descriptor: 'strikeAttack',
-                defaultValue: StatisticScale.moderate
+                defaultValue: StatisticOptions.moderate
             },
             {
                 name: AdjustableStatistics.strikeDamage,
                 actorField: 'none',
                 descriptor: 'strikeDamage',
-                defaultValue: StatisticScale.moderate
+                defaultValue: StatisticOptions.moderate
             }]
+    },
+    {
+        name: AdjustableStatistics.spellcasting,
+        descriptor: 'spellcasting',
+        availableValues: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.none],
+        associatedValues: [
+            {
+                actorField: 'none',
+                defaultValue: StatisticOptions.none
+            },
+        ]
     }
 ]
 
@@ -270,54 +282,54 @@ export const ROADMAPS: Roadmap[] = [
         name: 'Brute',
         tooltip: 'low Perception; high or extreme Str modifier, high to moderate Con modifier, low or lower Dex and mental modifiers; moderate or low AC; high Fortitude, low Reflex or Will or both; high HP; high attack bonus and high damage or moderate attack bonus and extreme damage',
         defaultValues: new Map([
-                [AdjustableStatistics.per, StatisticScale.low],
-                [AdjustableStatistics.str, StatisticScale.high],
-                [AdjustableStatistics.con, StatisticScale.high],
-                [AdjustableStatistics.dex, StatisticScale.low],
-                [AdjustableStatistics.int, StatisticScale.low],
-                [AdjustableStatistics.wis, StatisticScale.low],
-                [AdjustableStatistics.cha, StatisticScale.low],
-                [AdjustableStatistics.ac, StatisticScale.moderate],
-                [AdjustableStatistics.fort, StatisticScale.high],
-                [AdjustableStatistics.wil, StatisticScale.low],
-                [AdjustableStatistics.ref, StatisticScale.low],
-                [AdjustableStatistics.hp, StatisticScale.high],
-                [AdjustableStatistics.strikeBonus, StatisticScale.high],
-                [AdjustableStatistics.strikeDamage, StatisticScale.high],
+                [AdjustableStatistics.per, StatisticOptions.low],
+                [AdjustableStatistics.str, StatisticOptions.high],
+                [AdjustableStatistics.con, StatisticOptions.high],
+                [AdjustableStatistics.dex, StatisticOptions.low],
+                [AdjustableStatistics.int, StatisticOptions.low],
+                [AdjustableStatistics.wis, StatisticOptions.low],
+                [AdjustableStatistics.cha, StatisticOptions.low],
+                [AdjustableStatistics.ac, StatisticOptions.moderate],
+                [AdjustableStatistics.fort, StatisticOptions.high],
+                [AdjustableStatistics.wil, StatisticOptions.low],
+                [AdjustableStatistics.ref, StatisticOptions.low],
+                [AdjustableStatistics.hp, StatisticOptions.high],
+                [AdjustableStatistics.strikeBonus, StatisticOptions.high],
+                [AdjustableStatistics.strikeDamage, StatisticOptions.high],
         ])
     },
     {
         name: 'Skirmisher',
         tooltip: 'high Dex modifier; low Fortitude, high Reflex; higher Speed than typical',
         defaultValues: new Map([
-            [AdjustableStatistics.dex, StatisticScale.high],
-            [AdjustableStatistics.fort, StatisticScale.low],
-            [AdjustableStatistics.ref, StatisticScale.high],
+            [AdjustableStatistics.dex, StatisticOptions.high],
+            [AdjustableStatistics.fort, StatisticOptions.low],
+            [AdjustableStatistics.ref, StatisticOptions.high],
         ])
     },
     {
         name: 'Sniper',
         tooltip: 'high Perception; high Dex modifier; low Fortitude, high Reflex; moderate to low HP; ranged Strikes have high attack bonus and damage or moderate attack bonus and extreme damage (melee Strikes are weaker)',
         defaultValues: new Map([
-            [AdjustableStatistics.per, StatisticScale.high],
-            [AdjustableStatistics.dex, StatisticScale.high],
-            [AdjustableStatistics.ac, StatisticScale.moderate],
-            [AdjustableStatistics.fort, StatisticScale.low],
-            [AdjustableStatistics.ref, StatisticScale.high],
-            [AdjustableStatistics.hp, StatisticScale.moderate],
-            [AdjustableStatistics.strikeBonus, StatisticScale.high],
-            [AdjustableStatistics.strikeDamage, StatisticScale.high],
+            [AdjustableStatistics.per, StatisticOptions.high],
+            [AdjustableStatistics.dex, StatisticOptions.high],
+            [AdjustableStatistics.ac, StatisticOptions.moderate],
+            [AdjustableStatistics.fort, StatisticOptions.low],
+            [AdjustableStatistics.ref, StatisticOptions.high],
+            [AdjustableStatistics.hp, StatisticOptions.moderate],
+            [AdjustableStatistics.strikeBonus, StatisticOptions.high],
+            [AdjustableStatistics.strikeDamage, StatisticOptions.high],
         ])
     },
     {
         name: 'Soldier',
         tooltip: 'high Str modifier; high to extreme AC; high Fortitude; high attack bonus and high damage; Attack of Opportunity or other tactical abilities',
         defaultValues: new Map([
-            [AdjustableStatistics.str, StatisticScale.high],
-            [AdjustableStatistics.ac, StatisticScale.high],
-            [AdjustableStatistics.fort, StatisticScale.high],
-            [AdjustableStatistics.strikeBonus, StatisticScale.high],
-            [AdjustableStatistics.strikeDamage, StatisticScale.high],
+            [AdjustableStatistics.str, StatisticOptions.high],
+            [AdjustableStatistics.ac, StatisticOptions.high],
+            [AdjustableStatistics.fort, StatisticOptions.high],
+            [AdjustableStatistics.strikeBonus, StatisticOptions.high],
+            [AdjustableStatistics.strikeDamage, StatisticOptions.high],
         ])
     },
 ]

--- a/src/module/creature-builder/CreatureBuilderData.ts
+++ b/src/module/creature-builder/CreatureBuilderData.ts
@@ -5,6 +5,7 @@ export enum ValueCategory {
     low = 'low',
     terrible = 'terrible',
     abysmal = 'abysmal',
+    none = 'none', // Required for values that would allow for a null option
 }
 
 export class CreatureValueEntry {
@@ -107,5 +108,17 @@ export const DefaultCreatureValues: CreatureValueCategory[] = [
                 availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible],
                 defaultValue: ValueCategory.moderate
             }]
+    },
+    {
+        name: 'Skills',
+        descriptor: 'skill',
+        associatedValues: [
+            {
+                name: 'Acrobatics',
+                actorField: 'none',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
+                defaultValue: ValueCategory.none
+            }
+            ]
     }
 ]

--- a/src/module/creature-builder/CreatureBuilderData.ts
+++ b/src/module/creature-builder/CreatureBuilderData.ts
@@ -1,0 +1,68 @@
+export enum ValueCategory {
+    extreme = 'extreme',
+    high = 'high',
+    moderate = 'moderate',
+    low = 'low',
+    terrible = 'terrible',
+    abysmal = 'abysmal',
+}
+
+export class CreatureValueEntry {
+    name: string;
+    descriptor: string;
+    actorField: string;
+    availableValues: ValueCategory[];
+    defaultValue: ValueCategory;
+}
+
+export const DefaultCreatureValues: CreatureValueEntry[] = [
+    {
+        name: 'Strength',
+        descriptor: 'abilityScore',
+        actorField: 'data.abilities.str.mod',
+        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
+        defaultValue: ValueCategory.moderate
+    },
+    {
+        name: 'Dexterity',
+        descriptor: 'abilityScore',
+        actorField: 'data.abilities.dex.mod',
+        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
+        defaultValue: ValueCategory.moderate
+    },
+    {
+        name: 'Constitution',
+        descriptor: 'abilityScore',
+        actorField: 'data.abilities.con.mod',
+        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
+        defaultValue: ValueCategory.moderate
+    },
+    {
+        name: 'Intelligence',
+        descriptor: 'abilityScore',
+        actorField: 'data.abilities.int.mod',
+        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
+        defaultValue: ValueCategory.moderate
+    },
+    {
+        name: 'Wisdom',
+        descriptor: 'abilityScore',
+        actorField: 'data.abilities.wis.mod',
+        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
+        defaultValue: ValueCategory.moderate
+    },
+    {
+        name: 'Charisma',
+        descriptor: 'abilityScore',
+        actorField: 'data.abilities.cha.mod',
+        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
+        defaultValue: ValueCategory.moderate
+    },
+    {
+        name: 'Perception',
+        descriptor: 'perception',
+        actorField: 'data.attributes.perception.value',
+        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible],
+        defaultValue: ValueCategory.moderate
+    },
+]

--- a/src/module/creature-builder/CreatureBuilderData.ts
+++ b/src/module/creature-builder/CreatureBuilderData.ts
@@ -118,7 +118,96 @@ export const DefaultCreatureValues: CreatureValueCategory[] = [
                 actorField: 'none',
                 availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
                 defaultValue: ValueCategory.none
-            }
-            ]
+            },
+            {
+                name: 'Arcana',
+                actorField: 'none',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
+                defaultValue: ValueCategory.none
+            },
+            {
+                name: 'Athletics',
+                actorField: 'none',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
+                defaultValue: ValueCategory.none
+            },
+            {
+                name: 'Crafting',
+                actorField: 'none',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
+                defaultValue: ValueCategory.none
+            },
+            {
+                name: 'Deception',
+                actorField: 'none',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
+                defaultValue: ValueCategory.none
+            },
+            {
+                name: 'Diplomacy',
+                actorField: 'none',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
+                defaultValue: ValueCategory.none
+            },
+            {
+                name: 'Intimidation',
+                actorField: 'none',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
+                defaultValue: ValueCategory.none
+            },
+            {
+                name: 'Medicine',
+                actorField: 'none',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
+                defaultValue: ValueCategory.none
+            },
+            {
+                name: 'Nature',
+                actorField: 'none',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
+                defaultValue: ValueCategory.none
+            },
+            {
+                name: 'Occultism',
+                actorField: 'none',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
+                defaultValue: ValueCategory.none
+            },
+            {
+                name: 'Performance',
+                actorField: 'none',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
+                defaultValue: ValueCategory.none
+            },
+            {
+                name: 'Religion',
+                actorField: 'none',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
+                defaultValue: ValueCategory.none
+            },
+            {
+                name: 'Society',
+                actorField: 'none',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
+                defaultValue: ValueCategory.none
+            },
+            {
+                name: 'Stealth',
+                actorField: 'none',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
+                defaultValue: ValueCategory.none
+            },
+            {
+                name: 'Survival',
+                actorField: 'none',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
+                defaultValue: ValueCategory.none
+            },
+            {
+                name: 'Thievery',
+                actorField: 'none',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
+                defaultValue: ValueCategory.none
+            }]
     }
 ]

--- a/src/module/creature-builder/CreatureBuilderData.ts
+++ b/src/module/creature-builder/CreatureBuilderData.ts
@@ -42,32 +42,33 @@ export enum StatisticOptions {
     none = 'none', // Required for values that would allow for a null option
 }
 
-export class CreatureValueEntry {
+export class CreatureStatisticEntry {
     name?: string; // Overrides values from the parent category
     descriptor?: string; // Overrides values from the parent category
     actorField: string;
     defaultValue: StatisticOptions;
 }
 
-export class CreatureValueCategory {
+export class CreatureStatisticCategory {
     name: string;
     descriptor: string;
-    availableValues: StatisticOptions[];
-    associatedValues: CreatureValueEntry[];
+    availableOptions: StatisticOptions[];
+    statisticEntries: CreatureStatisticEntry[];
 }
 
+// See [aon](http://2e.aonprd.com/Rules.aspx?ID=995)
 export class Roadmap {
     name: string;
     tooltip: string;
     defaultValues: Map<string, StatisticOptions>;
 }
 
-export const DefaultCreatureValues: CreatureValueCategory[] = [
+export const DefaultCreatureStatistics: CreatureStatisticCategory[] = [
     {
         name: 'Abilities',
         descriptor: 'abilityScore',
-        availableValues: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low, StatisticOptions.terrible, StatisticOptions.abysmal],
-        associatedValues: [
+        availableOptions: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low, StatisticOptions.terrible, StatisticOptions.abysmal],
+        statisticEntries: [
             {
                 name: AdjustableStatistics.str,
                 actorField: 'data.abilities.str.mod',
@@ -103,8 +104,8 @@ export const DefaultCreatureValues: CreatureValueCategory[] = [
     {
         name: AdjustableStatistics.per,
         descriptor: 'perception',
-        availableValues: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low, StatisticOptions.terrible],
-        associatedValues: [
+        availableOptions: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low, StatisticOptions.terrible],
+        statisticEntries: [
             {
                 actorField: 'data.attributes.perception.value',
                 defaultValue: StatisticOptions.moderate
@@ -114,8 +115,8 @@ export const DefaultCreatureValues: CreatureValueCategory[] = [
     {
         name: AdjustableStatistics.ac,
         descriptor: 'armorClass',
-        availableValues: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low],
-        associatedValues: [
+        availableOptions: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low],
+        statisticEntries: [
             {
                 actorField: 'data.attributes.ac.value',
                 defaultValue: StatisticOptions.moderate
@@ -125,8 +126,8 @@ export const DefaultCreatureValues: CreatureValueCategory[] = [
     {
         name: AdjustableStatistics.hp,
         descriptor: 'hitPoints',
-        availableValues: [StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low],
-        associatedValues: [
+        availableOptions: [StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low],
+        statisticEntries: [
             {
                 actorField: 'data.attributes.hp.value,data.attributes.hp.max',
                 defaultValue: StatisticOptions.moderate
@@ -136,8 +137,8 @@ export const DefaultCreatureValues: CreatureValueCategory[] = [
     {
         name: 'Saving Throws',
         descriptor: 'savingThrow',
-        availableValues: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low, StatisticOptions.terrible],
-        associatedValues: [
+        availableOptions: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low, StatisticOptions.terrible],
+        statisticEntries: [
             {
                 name: AdjustableStatistics.fort,
                 actorField: 'data.saves.fortitude.value',
@@ -157,8 +158,8 @@ export const DefaultCreatureValues: CreatureValueCategory[] = [
     {
         name: 'Skills',
         descriptor: 'skill',
-        availableValues: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low, StatisticOptions.none],
-        associatedValues: [
+        availableOptions: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low, StatisticOptions.none],
+        statisticEntries: [
             {
                 name: AdjustableStatistics.acrobatics,
                 actorField: 'none',
@@ -243,8 +244,8 @@ export const DefaultCreatureValues: CreatureValueCategory[] = [
     {
         name: 'Strike',
         descriptor: 'strike',
-        availableValues: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low],
-        associatedValues: [
+        availableOptions: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.low],
+        statisticEntries: [
             {
                 name: AdjustableStatistics.strikeBonus,
                 actorField: 'none',
@@ -261,8 +262,8 @@ export const DefaultCreatureValues: CreatureValueCategory[] = [
     {
         name: AdjustableStatistics.spellcasting,
         descriptor: 'spellcasting',
-        availableValues: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.none],
-        associatedValues: [
+        availableOptions: [StatisticOptions.extreme, StatisticOptions.high, StatisticOptions.moderate, StatisticOptions.none],
+        statisticEntries: [
             {
                 actorField: 'none',
                 defaultValue: StatisticOptions.none
@@ -274,7 +275,7 @@ export const DefaultCreatureValues: CreatureValueCategory[] = [
 export const ROADMAPS: Roadmap[] = [
     {
         name: 'Average Joe',
-        tooltip: 'Set all values to moderate',
+        tooltip: 'Set all values to moderate, no spellcasting, no skills',
         defaultValues: new Map([
         ])
     },

--- a/src/module/creature-builder/CreatureBuilderData.ts
+++ b/src/module/creature-builder/CreatureBuilderData.ts
@@ -1,4 +1,4 @@
-export enum ValueCategory {
+export enum StatisticScale {
     extreme = 'extreme',
     high = 'high',
     moderate = 'moderate',
@@ -45,218 +45,225 @@ export class CreatureValueEntry {
     name?: string; // Overrides values from the parent category
     descriptor?: string; // Overrides values from the parent category
     actorField: string;
-    defaultValue: ValueCategory;
+    defaultValue: StatisticScale;
 }
 
 export class CreatureValueCategory {
     name: string;
     descriptor: string;
-    availableValues: ValueCategory[];
+    availableValues: StatisticScale[];
     associatedValues: CreatureValueEntry[];
 }
 
-/* export class RoadmapDefaultValue {
-    category: name
-}
-
 export class Roadmap {
-    defaultValues
-} */
+    name: string;
+    defaultValues: Map<string, StatisticScale>;
+}
 
 export const DefaultCreatureValues: CreatureValueCategory[] = [
     {
         name: 'Abilities',
         descriptor: 'abilityScore',
-        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
+        availableValues: [StatisticScale.extreme, StatisticScale.high, StatisticScale.moderate, StatisticScale.low, StatisticScale.terrible, StatisticScale.abysmal],
         associatedValues: [
             {
                 name: AdjustableStatistics.str,
                 actorField: 'data.abilities.str.mod',
-                defaultValue: ValueCategory.moderate
+                defaultValue: StatisticScale.moderate
             },
             {
                 name: AdjustableStatistics.dex,
                 actorField: 'data.abilities.dex.mod',
-                defaultValue: ValueCategory.moderate
+                defaultValue: StatisticScale.moderate
             },
             {
                 name: AdjustableStatistics.con,
                 actorField: 'data.abilities.con.mod',
-                defaultValue: ValueCategory.moderate
+                defaultValue: StatisticScale.moderate
             },
             {
                 name: AdjustableStatistics.int,
                 actorField: 'data.abilities.int.mod',
-                defaultValue: ValueCategory.moderate
+                defaultValue: StatisticScale.moderate
             },
             {
                 name: AdjustableStatistics.wis,
                 actorField: 'data.abilities.wis.mod',
-                defaultValue: ValueCategory.moderate
+                defaultValue: StatisticScale.moderate
             },
             {
                 name: AdjustableStatistics.cha,
                 actorField: 'data.abilities.cha.mod',
-                defaultValue: ValueCategory.moderate
+                defaultValue: StatisticScale.moderate
             }
         ]
     },
     {
         name: AdjustableStatistics.per,
         descriptor: 'perception',
-        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible],
+        availableValues: [StatisticScale.extreme, StatisticScale.high, StatisticScale.moderate, StatisticScale.low, StatisticScale.terrible],
         associatedValues: [
             {
                 actorField: 'data.attributes.perception.value',
-                defaultValue: ValueCategory.moderate
+                defaultValue: StatisticScale.moderate
             }
         ]
     },
     {
         name: AdjustableStatistics.ac,
         descriptor: 'armorClass',
-        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low],
+        availableValues: [StatisticScale.extreme, StatisticScale.high, StatisticScale.moderate, StatisticScale.low],
         associatedValues: [
             {
                 actorField: 'data.attributes.ac.value',
-                defaultValue: ValueCategory.moderate
+                defaultValue: StatisticScale.moderate
             }
         ]
     },
     {
         name: AdjustableStatistics.hp,
         descriptor: 'hitPoints',
-        availableValues: [ValueCategory.high, ValueCategory.moderate, ValueCategory.low],
+        availableValues: [StatisticScale.high, StatisticScale.moderate, StatisticScale.low],
         associatedValues: [
             {
                 actorField: 'data.attributes.hp.value,data.attributes.hp.max',
-                defaultValue: ValueCategory.moderate
+                defaultValue: StatisticScale.moderate
             }
         ]
     },
     {
         name: 'Saving Throws',
         descriptor: 'savingThrow',
-        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible],
+        availableValues: [StatisticScale.extreme, StatisticScale.high, StatisticScale.moderate, StatisticScale.low, StatisticScale.terrible],
         associatedValues: [
             {
                 name: AdjustableStatistics.fort,
                 actorField: 'data.saves.fortitude.value',
-                defaultValue: ValueCategory.moderate
+                defaultValue: StatisticScale.moderate
             },
             {
                 name: AdjustableStatistics.ref,
                 actorField: 'data.saves.reflex.value',
-                defaultValue: ValueCategory.moderate
+                defaultValue: StatisticScale.moderate
             },
             {
                 name: AdjustableStatistics.wil,
                 actorField: 'data.saves.will.value',
-                defaultValue: ValueCategory.moderate
+                defaultValue: StatisticScale.moderate
             }]
     },
     {
         name: 'Skills',
         descriptor: 'skill',
-        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
+        availableValues: [StatisticScale.extreme, StatisticScale.high, StatisticScale.moderate, StatisticScale.low, StatisticScale.none],
         associatedValues: [
             {
                 name: AdjustableStatistics.acrobatics,
                 actorField: 'none',
-                defaultValue: ValueCategory.none
+                defaultValue: StatisticScale.none
             },
             {
                 name: AdjustableStatistics.arcana,
                 actorField: 'none',
-                defaultValue: ValueCategory.none
+                defaultValue: StatisticScale.none
             },
             {
                 name: AdjustableStatistics.athletics,
                 actorField: 'none',
-                defaultValue: ValueCategory.none
+                defaultValue: StatisticScale.none
             },
             {
                 name: AdjustableStatistics.crafting,
                 actorField: 'none',
-                defaultValue: ValueCategory.none
+                defaultValue: StatisticScale.none
             },
             {
                 name: AdjustableStatistics.crafting,
                 actorField: 'none',
-                defaultValue: ValueCategory.none
+                defaultValue: StatisticScale.none
             },
             {
                 name: AdjustableStatistics.diplomacy,
                 actorField: 'none',
-                defaultValue: ValueCategory.none
+                defaultValue: StatisticScale.none
             },
             {
                 name: AdjustableStatistics.intimidation,
                 actorField: 'none',
-                defaultValue: ValueCategory.none
+                defaultValue: StatisticScale.none
             },
             {
                 name: AdjustableStatistics.medicine,
                 actorField: 'none',
-                defaultValue: ValueCategory.none
+                defaultValue: StatisticScale.none
             },
             {
                 name: AdjustableStatistics.medicine,
                 actorField: 'none',
-                defaultValue: ValueCategory.none
+                defaultValue: StatisticScale.none
             },
             {
                 name: AdjustableStatistics.occultism,
                 actorField: 'none',
-                defaultValue: ValueCategory.none
+                defaultValue: StatisticScale.none
             },
             {
                 name: AdjustableStatistics.performance,
                 actorField: 'none',
-                defaultValue: ValueCategory.none
+                defaultValue: StatisticScale.none
             },
             {
                 name: AdjustableStatistics.religion,
                 actorField: 'none',
-                defaultValue: ValueCategory.none
+                defaultValue: StatisticScale.none
             },
             {
                 name: AdjustableStatistics.society,
                 actorField: 'none',
-                defaultValue: ValueCategory.none
+                defaultValue: StatisticScale.none
             },
             {
                 name: AdjustableStatistics.stealth,
                 actorField: 'none',
-                defaultValue: ValueCategory.none
+                defaultValue: StatisticScale.none
             },
             {
                 name: AdjustableStatistics.survival,
                 actorField: 'none',
-                defaultValue: ValueCategory.none
+                defaultValue: StatisticScale.none
             },
             {
                 name: AdjustableStatistics.thievery,
                 actorField: 'none',
-                defaultValue: ValueCategory.none
+                defaultValue: StatisticScale.none
             }]
     },
     {
         name: 'Strike',
         descriptor: 'strike',
-        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low],
+        availableValues: [StatisticScale.extreme, StatisticScale.high, StatisticScale.moderate, StatisticScale.low],
         associatedValues: [
             {
                 name: AdjustableStatistics.strikeBonus,
                 actorField: 'none',
                 descriptor: 'strikeAttack',
-                defaultValue: ValueCategory.moderate
+                defaultValue: StatisticScale.moderate
             },
             {
                 name: AdjustableStatistics.strikeDamage,
                 actorField: 'none',
                 descriptor: 'strikeDamage',
-                defaultValue: ValueCategory.moderate
+                defaultValue: StatisticScale.moderate
             }]
     }
 ]
+
+export const ROADMAPS: Roadmap[] = [
+    {
+        name: 'Brute',
+        defaultValues: new Map([
+                [AdjustableStatistics.per, StatisticScale.low]
+        ])
+    }
+]
+

--- a/src/module/creature-builder/CreatureBuilderData.ts
+++ b/src/module/creature-builder/CreatureBuilderData.ts
@@ -178,7 +178,7 @@ export const DefaultCreatureValues: CreatureValueCategory[] = [
                 defaultValue: StatisticScale.none
             },
             {
-                name: AdjustableStatistics.crafting,
+                name: AdjustableStatistics.deception,
                 actorField: 'none',
                 defaultValue: StatisticScale.none
             },
@@ -198,7 +198,7 @@ export const DefaultCreatureValues: CreatureValueCategory[] = [
                 defaultValue: StatisticScale.none
             },
             {
-                name: AdjustableStatistics.medicine,
+                name: AdjustableStatistics.nature,
                 actorField: 'none',
                 defaultValue: StatisticScale.none
             },
@@ -260,16 +260,59 @@ export const DefaultCreatureValues: CreatureValueCategory[] = [
 
 export const ROADMAPS: Roadmap[] = [
     {
-        name: 'Brute',
+        name: 'Average Joe',
         defaultValues: new Map([
-                [AdjustableStatistics.per, StatisticScale.low]
         ])
     },
     {
-        name: 'Brute2',
+        name: 'Brute',
         defaultValues: new Map([
-            [AdjustableStatistics.per, StatisticScale.high]
+                [AdjustableStatistics.per, StatisticScale.low],
+                [AdjustableStatistics.str, StatisticScale.high],
+                [AdjustableStatistics.con, StatisticScale.high],
+                [AdjustableStatistics.dex, StatisticScale.low],
+                [AdjustableStatistics.int, StatisticScale.low],
+                [AdjustableStatistics.wis, StatisticScale.low],
+                [AdjustableStatistics.cha, StatisticScale.low],
+                [AdjustableStatistics.ac, StatisticScale.moderate],
+                [AdjustableStatistics.fort, StatisticScale.high],
+                [AdjustableStatistics.wil, StatisticScale.low],
+                [AdjustableStatistics.ref, StatisticScale.low],
+                [AdjustableStatistics.hp, StatisticScale.high],
+                [AdjustableStatistics.strikeBonus, StatisticScale.high],
+                [AdjustableStatistics.strikeDamage, StatisticScale.high],
         ])
-    }
+    },
+    {
+        name: 'Skirmisher',
+        defaultValues: new Map([
+            [AdjustableStatistics.dex, StatisticScale.high],
+            [AdjustableStatistics.fort, StatisticScale.low],
+            [AdjustableStatistics.ref, StatisticScale.high],
+        ])
+    },
+    {
+        name: 'Sniper',
+        defaultValues: new Map([
+            [AdjustableStatistics.per, StatisticScale.high],
+            [AdjustableStatistics.dex, StatisticScale.high],
+            [AdjustableStatistics.ac, StatisticScale.moderate],
+            [AdjustableStatistics.fort, StatisticScale.low],
+            [AdjustableStatistics.ref, StatisticScale.high],
+            [AdjustableStatistics.hp, StatisticScale.moderate],
+            [AdjustableStatistics.strikeBonus, StatisticScale.high],
+            [AdjustableStatistics.strikeDamage, StatisticScale.high],
+        ])
+    },
+    {
+        name: 'Soldier',
+        defaultValues: new Map([
+            [AdjustableStatistics.str, StatisticScale.high],
+            [AdjustableStatistics.ac, StatisticScale.high],
+            [AdjustableStatistics.fort, StatisticScale.high],
+            [AdjustableStatistics.strikeBonus, StatisticScale.high],
+            [AdjustableStatistics.strikeDamage, StatisticScale.high],
+        ])
+    },
 ]
 

--- a/src/module/creature-builder/CreatureBuilderData.ts
+++ b/src/module/creature-builder/CreatureBuilderData.ts
@@ -299,6 +299,15 @@ export const ROADMAPS: Roadmap[] = [
         ])
     },
     {
+        name: 'Magical Striker',
+        tooltip: 'high attack and high damage; moderate to high spell DCs; either a scattering of innate spells or prepared or spontaneous spells up to half the creature’s level (rounded up) minus 1',
+        defaultValues: new Map([
+                [AdjustableStatistics.spellcasting, StatisticOptions.moderate],
+                [AdjustableStatistics.strikeBonus, StatisticOptions.high],
+                [AdjustableStatistics.strikeDamage, StatisticOptions.high],
+        ])
+    },
+    {
         name: 'Skirmisher',
         tooltip: 'high Dex modifier; low Fortitude, high Reflex; higher Speed than typical',
         defaultValues: new Map([
@@ -330,6 +339,19 @@ export const ROADMAPS: Roadmap[] = [
             [AdjustableStatistics.fort, StatisticOptions.high],
             [AdjustableStatistics.strikeBonus, StatisticOptions.high],
             [AdjustableStatistics.strikeDamage, StatisticOptions.high],
+        ])
+    },
+    {
+        name: 'Spellcaster',
+        tooltip: 'high or extreme modifier for the corresponding mental ability; low Fortitude, high Will; low HP; low attack bonus and moderate or low damage; high or extreme spell DCs; prepared or spontaneous spells up to half the creature’s level (rounded up)',
+        defaultValues: new Map([
+            [AdjustableStatistics.int, StatisticOptions.high],
+            [AdjustableStatistics.fort, StatisticOptions.low],
+            [AdjustableStatistics.wil, StatisticOptions.high],
+            [AdjustableStatistics.hp, StatisticOptions.low],
+            [AdjustableStatistics.strikeBonus, StatisticOptions.low],
+            [AdjustableStatistics.strikeDamage, StatisticOptions.low],
+            [AdjustableStatistics.spellcasting, StatisticOptions.high],
         ])
     },
 ]

--- a/src/module/creature-builder/CreatureBuilderData.ts
+++ b/src/module/creature-builder/CreatureBuilderData.ts
@@ -88,6 +88,17 @@ export const DefaultCreatureValues: CreatureValueCategory[] = [
         ]
     },
     {
+        name: 'Hit Points',
+        descriptor: 'hitPoints',
+        associatedValues: [
+            {
+                actorField: 'data.attributes.hp.value,data.attributes.hp.max',
+                availableValues: [ValueCategory.high, ValueCategory.moderate, ValueCategory.low],
+                defaultValue: ValueCategory.moderate
+            }
+        ]
+    },
+    {
         name: 'Saving Throws',
         descriptor: 'savingThrow',
         associatedValues: [

--- a/src/module/creature-builder/CreatureBuilderData.ts
+++ b/src/module/creature-builder/CreatureBuilderData.ts
@@ -264,6 +264,12 @@ export const ROADMAPS: Roadmap[] = [
         defaultValues: new Map([
                 [AdjustableStatistics.per, StatisticScale.low]
         ])
+    },
+    {
+        name: 'Brute2',
+        defaultValues: new Map([
+            [AdjustableStatistics.per, StatisticScale.high]
+        ])
     }
 ]
 

--- a/src/module/creature-builder/CreatureBuilderData.ts
+++ b/src/module/creature-builder/CreatureBuilderData.ts
@@ -22,7 +22,7 @@ export class CreatureValueCategory {
 
 export const DefaultCreatureValues: CreatureValueCategory[] = [
     {
-        name: 'Ability',
+        name: 'Abilities',
         descriptor: 'abilityScore',
         associatedValues: [
             {
@@ -86,7 +86,7 @@ export const DefaultCreatureValues: CreatureValueCategory[] = [
         ]
     },
     {
-        name: 'Saves',
+        name: 'Saving Throws',
         descriptor: 'savingThrow',
         associatedValues: [
             {

--- a/src/module/creature-builder/CreatureBuilderData.ts
+++ b/src/module/creature-builder/CreatureBuilderData.ts
@@ -57,6 +57,7 @@ export class CreatureValueCategory {
 
 export class Roadmap {
     name: string;
+    tooltip: string;
     defaultValues: Map<string, StatisticScale>;
 }
 
@@ -261,11 +262,13 @@ export const DefaultCreatureValues: CreatureValueCategory[] = [
 export const ROADMAPS: Roadmap[] = [
     {
         name: 'Average Joe',
+        tooltip: 'Set all values to moderate',
         defaultValues: new Map([
         ])
     },
     {
         name: 'Brute',
+        tooltip: 'low Perception; high or extreme Str modifier, high to moderate Con modifier, low or lower Dex and mental modifiers; moderate or low AC; high Fortitude, low Reflex or Will or both; high HP; high attack bonus and high damage or moderate attack bonus and extreme damage',
         defaultValues: new Map([
                 [AdjustableStatistics.per, StatisticScale.low],
                 [AdjustableStatistics.str, StatisticScale.high],
@@ -285,6 +288,7 @@ export const ROADMAPS: Roadmap[] = [
     },
     {
         name: 'Skirmisher',
+        tooltip: 'high Dex modifier; low Fortitude, high Reflex; higher Speed than typical',
         defaultValues: new Map([
             [AdjustableStatistics.dex, StatisticScale.high],
             [AdjustableStatistics.fort, StatisticScale.low],
@@ -293,6 +297,7 @@ export const ROADMAPS: Roadmap[] = [
     },
     {
         name: 'Sniper',
+        tooltip: 'high Perception; high Dex modifier; low Fortitude, high Reflex; moderate to low HP; ranged Strikes have high attack bonus and damage or moderate attack bonus and extreme damage (melee Strikes are weaker)',
         defaultValues: new Map([
             [AdjustableStatistics.per, StatisticScale.high],
             [AdjustableStatistics.dex, StatisticScale.high],
@@ -306,6 +311,7 @@ export const ROADMAPS: Roadmap[] = [
     },
     {
         name: 'Soldier',
+        tooltip: 'high Str modifier; high to extreme AC; high Fortitude; high attack bonus and high damage; Attack of Opportunity or other tactical abilities',
         defaultValues: new Map([
             [AdjustableStatistics.str, StatisticScale.high],
             [AdjustableStatistics.ac, StatisticScale.high],

--- a/src/module/creature-builder/CreatureBuilderData.ts
+++ b/src/module/creature-builder/CreatureBuilderData.ts
@@ -9,7 +9,8 @@ export enum ValueCategory {
 }
 
 export class CreatureValueEntry {
-    name?: string;
+    name?: string; // Overrides values from the parent category
+    descriptor?: string; // Overrides values from the parent category
     actorField: string;
     availableValues: ValueCategory[];
     defaultValue: ValueCategory;
@@ -208,6 +209,25 @@ export const DefaultCreatureValues: CreatureValueCategory[] = [
                 actorField: 'none',
                 availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
                 defaultValue: ValueCategory.none
+            }]
+    },
+    {
+        name: 'Strike',
+        descriptor: 'strike',
+        associatedValues: [
+            {
+                name: 'Strike Attack Bonus',
+                actorField: 'none',
+                descriptor: 'strikeAttack',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low],
+                defaultValue: ValueCategory.moderate
+            },
+            {
+                name: 'Strike Damage',
+                actorField: 'none',
+                descriptor: 'strikeDamage',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low],
+                defaultValue: ValueCategory.moderate
             }]
     }
 ]

--- a/src/module/creature-builder/CreatureBuilderData.ts
+++ b/src/module/creature-builder/CreatureBuilderData.ts
@@ -8,92 +8,128 @@ export enum ValueCategory {
     none = 'none', // Required for values that would allow for a null option
 }
 
+export enum AdjustableStatistics {
+    str = 'Strength',
+    dex = 'Dexterity',
+    con = 'Constitution',
+    int = 'Intelligence',
+    wis = 'Wisdom',
+    cha = 'Charisma',
+    per = 'Perception',
+    ac = 'Armor Class',
+    hp = 'Hit Points',
+    fort = 'Fortitude',
+    ref = 'Reflex',
+    wil = 'Will',
+    acrobatics = 'Acrobatics',
+    arcana = 'Arcana',
+    athletics = 'Athletics',
+    crafting = 'Crafting',
+    deception = 'Deception',
+    diplomacy = 'Diplomacy',
+    intimidation = 'Intimidation',
+    medicine = 'Medicine',
+    nature = 'Nature',
+    occultism = 'Occultism',
+    performance = 'Performance',
+    religion = 'Religion',
+    society = 'Society',
+    stealth = 'Stealth',
+    survival = 'Survival',
+    thievery = 'Thievery',
+    strikeBonus = 'Strike Attack Bonus',
+    strikeDamage = 'Strike Damage',
+}
+
 export class CreatureValueEntry {
     name?: string; // Overrides values from the parent category
     descriptor?: string; // Overrides values from the parent category
     actorField: string;
-    availableValues: ValueCategory[];
     defaultValue: ValueCategory;
 }
 
 export class CreatureValueCategory {
     name: string;
     descriptor: string;
+    availableValues: ValueCategory[];
     associatedValues: CreatureValueEntry[];
 }
+
+/* export class RoadmapDefaultValue {
+    category: name
+}
+
+export class Roadmap {
+    defaultValues
+} */
 
 export const DefaultCreatureValues: CreatureValueCategory[] = [
     {
         name: 'Abilities',
         descriptor: 'abilityScore',
+        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
         associatedValues: [
             {
-                name: 'Strength',
+                name: AdjustableStatistics.str,
                 actorField: 'data.abilities.str.mod',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
                 defaultValue: ValueCategory.moderate
             },
             {
-                name: 'Dexterity',
+                name: AdjustableStatistics.dex,
                 actorField: 'data.abilities.dex.mod',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
                 defaultValue: ValueCategory.moderate
             },
             {
-                name: 'Constitution',
+                name: AdjustableStatistics.con,
                 actorField: 'data.abilities.con.mod',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
                 defaultValue: ValueCategory.moderate
             },
             {
-                name: 'Intelligence',
+                name: AdjustableStatistics.int,
                 actorField: 'data.abilities.int.mod',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
                 defaultValue: ValueCategory.moderate
             },
             {
-                name: 'Wisdom',
+                name: AdjustableStatistics.wis,
                 actorField: 'data.abilities.wis.mod',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
                 defaultValue: ValueCategory.moderate
             },
             {
-                name: 'Charisma',
+                name: AdjustableStatistics.cha,
                 actorField: 'data.abilities.cha.mod',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
                 defaultValue: ValueCategory.moderate
             }
         ]
     },
     {
-        name: 'Perception',
+        name: AdjustableStatistics.per,
         descriptor: 'perception',
+        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible],
         associatedValues: [
             {
                 actorField: 'data.attributes.perception.value',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible],
                 defaultValue: ValueCategory.moderate
             }
         ]
     },
     {
-        name: 'Armor Class',
+        name: AdjustableStatistics.ac,
         descriptor: 'armorClass',
+        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low],
         associatedValues: [
             {
                 actorField: 'data.attributes.ac.value',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low],
                 defaultValue: ValueCategory.moderate
             }
         ]
     },
     {
-        name: 'Hit Points',
+        name: AdjustableStatistics.hp,
         descriptor: 'hitPoints',
+        availableValues: [ValueCategory.high, ValueCategory.moderate, ValueCategory.low],
         associatedValues: [
             {
                 actorField: 'data.attributes.hp.value,data.attributes.hp.max',
-                availableValues: [ValueCategory.high, ValueCategory.moderate, ValueCategory.low],
                 defaultValue: ValueCategory.moderate
             }
         ]
@@ -101,143 +137,125 @@ export const DefaultCreatureValues: CreatureValueCategory[] = [
     {
         name: 'Saving Throws',
         descriptor: 'savingThrow',
+        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible],
         associatedValues: [
             {
-                name: 'Fortitude',
+                name: AdjustableStatistics.fort,
                 actorField: 'data.saves.fortitude.value',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible],
                 defaultValue: ValueCategory.moderate
             },
             {
-                name: 'Reflex',
+                name: AdjustableStatistics.ref,
                 actorField: 'data.saves.reflex.value',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible],
                 defaultValue: ValueCategory.moderate
             },
             {
-                name: 'Will',
+                name: AdjustableStatistics.wil,
                 actorField: 'data.saves.will.value',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible],
                 defaultValue: ValueCategory.moderate
             }]
     },
     {
         name: 'Skills',
         descriptor: 'skill',
+        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
         associatedValues: [
             {
-                name: 'Acrobatics',
+                name: AdjustableStatistics.acrobatics,
                 actorField: 'none',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
                 defaultValue: ValueCategory.none
             },
             {
-                name: 'Arcana',
+                name: AdjustableStatistics.arcana,
                 actorField: 'none',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
                 defaultValue: ValueCategory.none
             },
             {
-                name: 'Athletics',
+                name: AdjustableStatistics.athletics,
                 actorField: 'none',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
                 defaultValue: ValueCategory.none
             },
             {
-                name: 'Crafting',
+                name: AdjustableStatistics.crafting,
                 actorField: 'none',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
                 defaultValue: ValueCategory.none
             },
             {
-                name: 'Deception',
+                name: AdjustableStatistics.crafting,
                 actorField: 'none',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
                 defaultValue: ValueCategory.none
             },
             {
-                name: 'Diplomacy',
+                name: AdjustableStatistics.diplomacy,
                 actorField: 'none',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
                 defaultValue: ValueCategory.none
             },
             {
-                name: 'Intimidation',
+                name: AdjustableStatistics.intimidation,
                 actorField: 'none',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
                 defaultValue: ValueCategory.none
             },
             {
-                name: 'Medicine',
+                name: AdjustableStatistics.medicine,
                 actorField: 'none',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
                 defaultValue: ValueCategory.none
             },
             {
-                name: 'Nature',
+                name: AdjustableStatistics.medicine,
                 actorField: 'none',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
                 defaultValue: ValueCategory.none
             },
             {
-                name: 'Occultism',
+                name: AdjustableStatistics.occultism,
                 actorField: 'none',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
                 defaultValue: ValueCategory.none
             },
             {
-                name: 'Performance',
+                name: AdjustableStatistics.performance,
                 actorField: 'none',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
                 defaultValue: ValueCategory.none
             },
             {
-                name: 'Religion',
+                name: AdjustableStatistics.religion,
                 actorField: 'none',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
                 defaultValue: ValueCategory.none
             },
             {
-                name: 'Society',
+                name: AdjustableStatistics.society,
                 actorField: 'none',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
                 defaultValue: ValueCategory.none
             },
             {
-                name: 'Stealth',
+                name: AdjustableStatistics.stealth,
                 actorField: 'none',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
                 defaultValue: ValueCategory.none
             },
             {
-                name: 'Survival',
+                name: AdjustableStatistics.survival,
                 actorField: 'none',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
                 defaultValue: ValueCategory.none
             },
             {
-                name: 'Thievery',
+                name: AdjustableStatistics.thievery,
                 actorField: 'none',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.none],
                 defaultValue: ValueCategory.none
             }]
     },
     {
         name: 'Strike',
         descriptor: 'strike',
+        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low],
         associatedValues: [
             {
-                name: 'Strike Attack Bonus',
+                name: AdjustableStatistics.strikeBonus,
                 actorField: 'none',
                 descriptor: 'strikeAttack',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low],
                 defaultValue: ValueCategory.moderate
             },
             {
-                name: 'Strike Damage',
+                name: AdjustableStatistics.strikeDamage,
                 actorField: 'none',
                 descriptor: 'strikeDamage',
-                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low],
                 defaultValue: ValueCategory.moderate
             }]
     }

--- a/src/module/creature-builder/CreatureBuilderData.ts
+++ b/src/module/creature-builder/CreatureBuilderData.ts
@@ -8,61 +8,104 @@ export enum ValueCategory {
 }
 
 export class CreatureValueEntry {
-    name: string;
-    descriptor: string;
+    name?: string;
     actorField: string;
     availableValues: ValueCategory[];
     defaultValue: ValueCategory;
 }
 
-export const DefaultCreatureValues: CreatureValueEntry[] = [
+export class CreatureValueCategory {
+    name: string;
+    descriptor: string;
+    associatedValues: CreatureValueEntry[];
+}
+
+export const DefaultCreatureValues: CreatureValueCategory[] = [
     {
-        name: 'Strength',
+        name: 'Ability',
         descriptor: 'abilityScore',
-        actorField: 'data.abilities.str.mod',
-        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
-        defaultValue: ValueCategory.moderate
-    },
-    {
-        name: 'Dexterity',
-        descriptor: 'abilityScore',
-        actorField: 'data.abilities.dex.mod',
-        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
-        defaultValue: ValueCategory.moderate
-    },
-    {
-        name: 'Constitution',
-        descriptor: 'abilityScore',
-        actorField: 'data.abilities.con.mod',
-        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
-        defaultValue: ValueCategory.moderate
-    },
-    {
-        name: 'Intelligence',
-        descriptor: 'abilityScore',
-        actorField: 'data.abilities.int.mod',
-        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
-        defaultValue: ValueCategory.moderate
-    },
-    {
-        name: 'Wisdom',
-        descriptor: 'abilityScore',
-        actorField: 'data.abilities.wis.mod',
-        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
-        defaultValue: ValueCategory.moderate
-    },
-    {
-        name: 'Charisma',
-        descriptor: 'abilityScore',
-        actorField: 'data.abilities.cha.mod',
-        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
-        defaultValue: ValueCategory.moderate
+        associatedValues: [
+            {
+                name: 'Strength',
+                actorField: 'data.abilities.str.mod',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
+                defaultValue: ValueCategory.moderate
+            },
+            {
+                name: 'Dexterity',
+                actorField: 'data.abilities.dex.mod',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
+                defaultValue: ValueCategory.moderate
+            },
+            {
+                name: 'Constitution',
+                actorField: 'data.abilities.con.mod',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
+                defaultValue: ValueCategory.moderate
+            },
+            {
+                name: 'Intelligence',
+                actorField: 'data.abilities.int.mod',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
+                defaultValue: ValueCategory.moderate
+            },
+            {
+                name: 'Wisdom',
+                actorField: 'data.abilities.wis.mod',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
+                defaultValue: ValueCategory.moderate
+            },
+            {
+                name: 'Charisma',
+                actorField: 'data.abilities.cha.mod',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible, ValueCategory.abysmal],
+                defaultValue: ValueCategory.moderate
+            }
+        ]
     },
     {
         name: 'Perception',
         descriptor: 'perception',
-        actorField: 'data.attributes.perception.value',
-        availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible],
-        defaultValue: ValueCategory.moderate
+        associatedValues: [
+            {
+                actorField: 'data.attributes.perception.value',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible],
+                defaultValue: ValueCategory.moderate
+            }
+        ]
     },
+    {
+        name: 'Armor Class',
+        descriptor: 'armorClass',
+        associatedValues: [
+            {
+                actorField: 'data.attributes.ac.value',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low],
+                defaultValue: ValueCategory.moderate
+            }
+        ]
+    },
+    {
+        name: 'Saves',
+        descriptor: 'savingThrow',
+        associatedValues: [
+            {
+                name: 'Fortitude',
+                actorField: 'data.saves.fortitude.value',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible],
+                defaultValue: ValueCategory.moderate
+            },
+            {
+                name: 'Reflex',
+                actorField: 'data.saves.reflex.value',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible],
+                defaultValue: ValueCategory.moderate
+            },
+            {
+                name: 'Will',
+                actorField: 'data.saves.will.value',
+                availableValues: [ValueCategory.extreme, ValueCategory.high, ValueCategory.moderate, ValueCategory.low, ValueCategory.terrible],
+                defaultValue: ValueCategory.moderate
+            }]
+    }
 ]

--- a/src/module/settings-app/Settings.ts
+++ b/src/module/settings-app/Settings.ts
@@ -18,6 +18,7 @@ import '../../external/settings-extender.js';
 import SettingsApp from './SettingsApp';
 
 const Features = {
+    CREATURE_BUILDER: 'CREATURE_BUILDER',
     DISABLE_PFS_TAB: 'DISABLE_PFS_TAB',
     FLATTEN_PROFICIENCY: 'FLATTEN_PROFICIENCY',
     HERO_POINTS: 'ENABLE_HERO_POINTS',
@@ -119,6 +120,26 @@ export const FEATURES: IFeatureDefinition[] = [
         register: [
             {
                 name: Features.ROLL_APP,
+                type: Boolean,
+                default: true,
+            },
+        ],
+    },
+    {
+        name: 'Creature Builder',
+        attributes: [ATTR_RELOAD_REQUIRED],
+        description: `A tool to build creatures from scratch using the recommended values from the GMG.`,
+        inputs: [
+            {
+                name: Features.CREATURE_BUILDER,
+                label: 'Enable',
+                type: 'checkbox',
+                value: true,
+            },
+        ],
+        register: [
+            {
+                name: Features.CREATURE_BUILDER,
                 type: Boolean,
                 default: true,
             },

--- a/src/templates/creature-builder/index.html
+++ b/src/templates/creature-builder/index.html
@@ -19,7 +19,7 @@
             <label for="road-map"><h2>Road Map</h2></label>
             <select id="road-map" >
                 {{#each roadMaps as |roadMap|}}
-                <option>{{roadMap.name}}</option>
+                <option title='{{roadMap.tooltip}}'>{{roadMap.name}}</option>
                 {{/each}}
             </select>
             <div class="btn apply-road-map"><a><i class="fas fa-plus"></i>Apply Road Map</a></div>

--- a/src/templates/creature-builder/index.html
+++ b/src/templates/creature-builder/index.html
@@ -15,16 +15,16 @@
             <label for="level">Level</label>
             <input name='data.details.level.value' id='level' type='number' value='{{object.data.details.level.value}}'>
         </div>
+        {{#each valueEntries as |valueEntry|}}
         <div>
-            <label for="perception-group">Perception</label>
-            <div id='perception-group'>
-                <input type="radio" name="perception" value='extreme' checked> Extreme
-                <input type="radio" name="perception" value='high'> High
-                <input type="radio" name="perception" value='moderate'> Moderate
-                <input type="radio" name="perception" value='low'> Low
-                <input type="radio" name="perception" value='terrible'> Terrible
+            <label for='{{valueEntry.descriptor}}-group'>{{valueEntry.descriptor}}</label>
+            <div id='{{valueEntry.descriptor}}-group'>
+                {{#each valueEntry.availableValues as |value|}}
+                <input type="radio" name='{{valueEntry.descriptor}}' value='{{value}}' {{#ifeq value valueEntry.defaultValue}} Checked {{/ifeq}}> {{value}}
+                {{/each}}
             </div>
         </div>
+        {{/each}}
     </div>
     <button type="submit" name="submit" value="1"><i class="far fa-save"></i>Build</button>
 </form>

--- a/src/templates/creature-builder/index.html
+++ b/src/templates/creature-builder/index.html
@@ -15,6 +15,15 @@
             <label for="level"><h2>Level</h2></label>
             <input name='data.details.level.value' id='level' type='number' value='{{object.data.details.level.value}}'>
         </div>
+        <div id='road-map-selector'>
+            <label for="road-map"><h2>Road Map</h2></label>
+            <select id="road-map" >
+                {{#each roadMaps as |roadMap|}}
+                <option>{{roadMap.name}}</option>
+                {{/each}}
+            </select>
+            <div class="btn apply-road-map"><a><i class="fas fa-plus"></i>Apply Road Map</a></div>
+        </div>
         {{#each valueCategories as |category|}}
         <div class='category'>
             <h2>{{category.name}}</h2>

--- a/src/templates/creature-builder/index.html
+++ b/src/templates/creature-builder/index.html
@@ -24,17 +24,17 @@
             </select>
             <div class="btn apply-road-map"><a><i class="fas fa-plus"></i>Apply Road Map</a></div>
         </div>
-        {{#each valueCategories as |category|}}
+        {{#each statisticCategories as |category|}}
         <div class='category'>
             <h2>{{category.name}}</h2>
-            {{#each category.associatedValues as |value|}}
-            <div class='value'>
-                <label for='{{value.name}}-group'><h3>{{value.name}}</h3></label>
-                <div id='{{value.name}}-group'>
-                    {{#each category.availableValues as |valueOption|}}
+            {{#each category.statisticEntries as |entry|}}
+            <div class='entry'>
+                <label for='{{entry.name}}-group'><h3>{{entry.name}}</h3></label>
+                <div id='{{entry.name}}-group'>
+                    {{#each category.availableOptions as |option|}}
                     <input type="radio"
-                           name='{{#if value.name}}{{value.name}}{{else}}{{category.name}}{{/if}}'
-                           value='{{valueOption}}' {{#ifeq valueOption value.defaultValue}} Checked {{/ifeq}}> {{valueOption}}
+                           name='{{#if entry.name}}{{entry.name}}{{else}}{{category.name}}{{/if}}'
+                           value='{{option}}' {{#ifeq option entry.defaultValue}} Checked {{/ifeq}}> {{option}}
                     {{/each}}
                 </div>
             </div>

--- a/src/templates/creature-builder/index.html
+++ b/src/templates/creature-builder/index.html
@@ -22,7 +22,7 @@
             <div class='value'>
                 <label for='{{value.name}}-group'><h3>{{value.name}}</h3></label>
                 <div id='{{value.name}}-group'>
-                    {{#each value.availableValues as |valueOption|}}
+                    {{#each category.availableValues as |valueOption|}}
                     <input type="radio"
                            name='{{#if value.name}}{{value.name}}{{else}}{{category.name}}{{/if}}'
                            value='{{valueOption}}' {{#ifeq valueOption value.defaultValue}} Checked {{/ifeq}}> {{valueOption}}

--- a/src/templates/creature-builder/index.html
+++ b/src/templates/creature-builder/index.html
@@ -17,10 +17,10 @@
         </div>
         {{#each valueEntries as |valueEntry|}}
         <div>
-            <label for='{{valueEntry.descriptor}}-group'>{{valueEntry.descriptor}}</label>
+            <label for='{{valueEntry.descriptor}}-group'>{{valueEntry.name}}</label>
             <div id='{{valueEntry.descriptor}}-group'>
                 {{#each valueEntry.availableValues as |value|}}
-                <input type="radio" name='{{valueEntry.descriptor}}' value='{{value}}' {{#ifeq value valueEntry.defaultValue}} Checked {{/ifeq}}> {{value}}
+                <input type="radio" name='{{valueEntry.name}}' value='{{value}}' {{#ifeq value valueEntry.defaultValue}} Checked {{/ifeq}}> {{value}}
                 {{/each}}
             </div>
         </div>

--- a/src/templates/creature-builder/index.html
+++ b/src/templates/creature-builder/index.html
@@ -15,14 +15,21 @@
             <label for="level">Level</label>
             <input name='data.details.level.value' id='level' type='number' value='{{object.data.details.level.value}}'>
         </div>
-        {{#each valueEntries as |valueEntry|}}
-        <div>
-            <label for='{{valueEntry.descriptor}}-group'>{{valueEntry.name}}</label>
-            <div id='{{valueEntry.descriptor}}-group'>
-                {{#each valueEntry.availableValues as |value|}}
-                <input type="radio" name='{{valueEntry.name}}' value='{{value}}' {{#ifeq value valueEntry.defaultValue}} Checked {{/ifeq}}> {{value}}
-                {{/each}}
+        {{#each valueCategories as |category|}}
+        <div class='category'>
+            <h3>{{category.name}}</h3>
+            {{#each category.associatedValues as |value|}}
+            <div class='value'>
+                <label for='{{value.name}}-group'>{{value.name}}</label>
+                <div id='{{value.name}}-group'>
+                    {{#each value.availableValues as |valueOption|}}
+                    <input type="radio"
+                           name='{{#if value.name}}{{value.name}}{{else}}{{category.name}}{{/if}}'
+                           value='{{valueOption}}' {{#ifeq valueOption value.defaultValue}} Checked {{/ifeq}}> {{valueOption}}
+                    {{/each}}
+                </div>
             </div>
+            {{/each}}
         </div>
         {{/each}}
     </div>

--- a/src/templates/creature-builder/index.html
+++ b/src/templates/creature-builder/index.html
@@ -1,0 +1,30 @@
+<form class="creature-builder" autocomplete="off" onsubmit="event.preventDefault();">
+    <label>{{ localize "PF2E.ScrollWandPopup.label" }}</label>
+    <div class="sheet-header">
+        <h1 class="charname">
+            <input
+                name="name"
+                type="text"
+                value="{{object.name}}"
+                placeholder="{{localize 'PF2E.loot.LootNamePlaceholder'}}"
+            />
+        </h1>
+    </div>
+    <div class='sheet-body'>
+        <div>
+            <label for="level">Level</label>
+            <input name='data.details.level.value' id='level' type='number' value='{{object.data.details.level.value}}'>
+        </div>
+        <div>
+            <label for="perception-group">Perception</label>
+            <div id='perception-group'>
+                <input type="radio" name="perception" value='extreme' checked> Extreme
+                <input type="radio" name="perception" value='high'> High
+                <input type="radio" name="perception" value='moderate'> Moderate
+                <input type="radio" name="perception" value='low'> Low
+                <input type="radio" name="perception" value='terrible'> Terrible
+            </div>
+        </div>
+    </div>
+    <button type="submit" name="submit" value="1"><i class="far fa-save"></i>Build</button>
+</form>

--- a/src/templates/creature-builder/index.html
+++ b/src/templates/creature-builder/index.html
@@ -1,26 +1,26 @@
 <form class="creature-builder" autocomplete="off" onsubmit="event.preventDefault();">
-    <label>{{ localize "PF2E.ScrollWandPopup.label" }}</label>
+    <label>Create the values of a creature from the values of the Game Mastery Guide</label>
     <div class="sheet-header">
         <h1 class="charname">
             <input
                 name="name"
                 type="text"
                 value="{{object.name}}"
-                placeholder="{{localize 'PF2E.loot.LootNamePlaceholder'}}"
+                placeholder="Character Name"
             />
         </h1>
     </div>
     <div class='sheet-body'>
         <div>
-            <label for="level">Level</label>
+            <label for="level"><h2>Level</h2></label>
             <input name='data.details.level.value' id='level' type='number' value='{{object.data.details.level.value}}'>
         </div>
         {{#each valueCategories as |category|}}
         <div class='category'>
-            <h3>{{category.name}}</h3>
+            <h2>{{category.name}}</h2>
             {{#each category.associatedValues as |value|}}
             <div class='value'>
-                <label for='{{value.name}}-group'>{{value.name}}</label>
+                <label for='{{value.name}}-group'><h3>{{value.name}}</h3></label>
                 <div id='{{value.name}}-group'>
                     {{#each value.availableValues as |valueOption|}}
                     <input type="radio"


### PR DESCRIPTION
This pull request contains a new creature builder. It allows the simple creation of creatures with the suggested values from the GMG. The button to open the menu is at the top of npc sheets.

Current Features are:
- Selecting Perception, Saves, Abilities, Skills, ac, hp and strikes from suggested values
- Apply templates Brute, Skirmisher, Sniper and Soldier

The feature set atm is still limited. Future features should include:
- Add spell stuff (dc, attacks, spell casting stuff)
- Add more templates (spell casters, classes, skill paragon)

![CreatureBuilderAdvancedPrototyp](https://user-images.githubusercontent.com/7985081/110217063-62b15780-7eb2-11eb-9287-73b09b25e275.png)