### PR TITLE
Update name of character sheet actor class (Fixes #32 and #33)

### DIFF
--- a/src/module/Main.ts
+++ b/src/module/Main.ts
@@ -48,10 +48,10 @@ Hooks.on('setup', () => {
         Hooks.on('renderJournalDirectory', enableRollAppButton);
     }
     if (Settings.get(Settings.FEATURES.HERO_POINTS)) {
-        Hooks.on('renderCRBStyleCharacterActorSheetPF2E', enableHeroPoints);
+        Hooks.on('renderCharacterSheetPF2e', enableHeroPoints);
     }
     if (Settings.get(Settings.FEATURES.DISABLE_PFS_TAB)) {
-        Hooks.on('renderCRBStyleCharacterActorSheetPF2E', disablePFSTab);
+        Hooks.on('renderCharacterSheetPF2e', disablePFSTab);
     }
     if (Settings.get(Settings.FEATURES.REMOVE_DEFAULT_ART)) {
         Hooks.on('ready', removeDefaultArt);
@@ -250,8 +250,8 @@ function enableQuickMystify() {
 
     CONFIG.Actor.sheetClasses['loot']['pf2e.ActorSheetPF2eLoot'].cls = decorate(CONFIG.Actor.sheetClasses['loot']['pf2e.ActorSheetPF2eLoot'].cls);
 
-    CONFIG.Actor.sheetClasses['character']['pf2e.CRBStyleCharacterActorSheetPF2E'].cls = decorate(
-        CONFIG.Actor.sheetClasses['character']['pf2e.CRBStyleCharacterActorSheetPF2E'].cls,
+    CONFIG.Actor.sheetClasses['character']['pf2e.CharacterSheetPF2e'].cls = decorate(
+        CONFIG.Actor.sheetClasses['character']['pf2e.CharacterSheetPF2e'].cls,
     );
 
     if (Settings.get(Settings.FEATURES.LOOT_APP)) {


### PR DESCRIPTION
Name of sheets was modified in the pf2e system in https://gitlab.com/hooking/foundry-vtt---pathfinder-2e/-/commit/c5af4312bd9ca510ad609f08de3ef6a1de647868
This should fix #32 and #33
![pf2eConfig](https://user-images.githubusercontent.com/23172861/111662940-a4c28d80-8810-11eb-902e-f6d35e4e8389.jpg)
